### PR TITLE
Load Socket Server URL from env

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -24,3 +24,5 @@ jobs:
         run: yarn tsc
       - name: Build example project
         run: yarn build
+        env:
+          SOCKET_SERVER_URL: not_null_but_also_not_a_valid_url

--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import styles from '../styles/Alert.module.css'
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,3 @@
-socketServerUrl: http://localhost:4000
 questions: 
   - 
     # This question type will only display a title

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,10 +15,16 @@ const sessionUuid = v4()
 type Props = {
   children?: React.ReactNode
   questions?: Question[]
-  socketServerUrl: string
+  socketServerUrl?: string
 }
 
 const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
+  if (!socketServerUrl) {
+    throw Error(
+      'SOCKET_SERVER_URL env variable not set. There is nowhere to send survey results!'
+    )
+  }
+
   const [activeQuestion, setActiveQuestion] = useState(0)
   const t = useTranslations()
 
@@ -107,14 +113,6 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
 }
 
 export const getStaticProps: GetStaticProps = async (context) => {
-  const socketServerUrl = process.env.SOCKET_SERVER_URL
-
-  if (!socketServerUrl) {
-    throw Error(
-      'SOCKET_SERVER_URL env variable not set, interface will not work properly.'
-    )
-  }
-
   const messages = config.i18n[context.locale as keyof typeof config.i18n]
   const questionMessages: Record<
     string,
@@ -154,7 +152,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     props: {
       messages: { ...messages, ...questionMessages },
       questions: localizedQuestions,
-      socketServerUrl
+      socketServerUrl: process.env.SOCKET_SERVER_URL
     }
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,13 +15,14 @@ const sessionUuid = v4()
 type Props = {
   children?: React.ReactNode
   questions?: Question[]
+  socketServerUrl: string
 }
 
-const Home: NextPage = ({ questions }: Props) => {
+const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
   const [activeQuestion, setActiveQuestion] = useState(0)
   const t = useTranslations()
 
-  const { connected, error, socket } = useSocket(config.socketServerUrl, {
+  const { connected, error, socket } = useSocket(socketServerUrl, {
     reconnectionAttempts: 5,
     reconnectionDelay: 1000
   })
@@ -106,6 +107,14 @@ const Home: NextPage = ({ questions }: Props) => {
 }
 
 export const getStaticProps: GetStaticProps = async (context) => {
+  const socketServerUrl = process.env.SOCKET_SERVER_URL
+
+  if (!socketServerUrl) {
+    throw Error(
+      'SOCKET_SERVER_URL env variable not set, interface will not work properly.'
+    )
+  }
+
   const messages = config.i18n[context.locale as keyof typeof config.i18n]
   const questionMessages: Record<
     string,
@@ -144,7 +153,8 @@ export const getStaticProps: GetStaticProps = async (context) => {
   return {
     props: {
       messages: { ...messages, ...questionMessages },
-      questions: localizedQuestions
+      questions: localizedQuestions,
+      socketServerUrl
     }
   }
 }


### PR DESCRIPTION
Loading it from config made it difficult to deploy to Vercel. Loading it from env instead makes it easier.

There is a chance we may have this problem again when we try to set the questions in the config -- I'm thinking we'll probably have to set a link to download an alternate config or encode the entire config file somehow. Curious for your thoughts.