### PR TITLE
Add `package.json` engine field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "survey",
   "version": "0.1.0",
+  "engines": {
+    "node": "<18"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Node 18 does _not_ work with the config download script. `package.json` is updated to reflect this