### PR TITLE
fix(server/util.js): don’t merge previously merged results

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ const { Server } = require('socket.io')
 
 const config = require('../server.config.json')
 
-const { concatenatePreviousDay } = require('./util')
+const { concatenatePreviousDay, generateDateString } = require('./util')
 
 const userQuestionMatrix = {}
 const userTimeouts = {}
@@ -36,10 +36,8 @@ const uploadUserData = async (user, data) => {
 
   const csv = parse(data)
   try {
-    const date = new Date()
-    const dateString = `${date.getFullYear()}-${
-      date.getMonth() + 1
-    }-${date.getDate()}`
+    const dateString = generateDateString()
+
     const upload = await new aws.S3.ManagedUpload({
       params: {
         Body: csv,

--- a/server/util.js
+++ b/server/util.js
@@ -30,7 +30,7 @@ const getS3ObjectContents = async (s3, bucket, key) => {
  * and therefore is a survey response
  */
 const objectIsSurveyResponse = (s3Object) =>
-  s3Object.Key.includes('survey-responses/')
+  s3Object.Key.includes('survey-responses/') && !s3Object.Key.includes('merged')
 
 /**
  * Uses the S3 object data to determine if an S3 object was modified in the past

--- a/server/util.js
+++ b/server/util.js
@@ -61,6 +61,16 @@ const padNumber = (number) => {
 }
 
 /**
+ * Returns the current date as a string, with padded zeroes
+ */
+const generateDateString = () => {
+  const date = new Date()
+  return `${date.getFullYear()}-${padNumber(date.getMonth() + 1)}-${padNumber(
+    date.getDate()
+  )}`
+}
+
+/**
  * Main method which gets all files created within the past 24 hours, concatenates them
  * into a single csv and then uploads that csv to the same bucket all the files were read from.
  */
@@ -99,11 +109,7 @@ const concatenatePreviousDay = async (aws) => {
   // Convert to csv and upload
   const parsed = parse(allResponses, { fields: allKeys.sort() })
   try {
-    // TODO: extract to own method
-    const date = new Date()
-    const dateString = `${date.getFullYear()}-${padNumber(
-      date.getMonth() + 1
-    )}-${padNumber(date.getDate())}`
+    const dateString = generateDateString()
 
     const upload = await new aws.S3.ManagedUpload({
       params: {
@@ -118,4 +124,4 @@ const concatenatePreviousDay = async (aws) => {
   }
 }
 
-module.exports = { concatenatePreviousDay }
+module.exports = { concatenatePreviousDay, generateDateString }


### PR DESCRIPTION
If for some reason the merge script was run twice in a day, the previously merged results would be merged in again. This PR rectifies this.