### PR TITLE
refactor(QuestionRenderer): support radio button default option index

### DIFF
--- a/components/QuestionRenderer.tsx
+++ b/components/QuestionRenderer.tsx
@@ -43,6 +43,7 @@ const QuestionRenderer = ({
       if (!('options' in question)) return failure
       return (
         <RadioButtons
+          defaultOptionIndex={question.defaultOptionIndex}
           disabled={disabled}
           options={question.options}
           title={title}


### PR DESCRIPTION
This behavior was previously unusable. This PR enables this prop.