### PR TITLE
Survey JSX a11y

### DIFF
--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -33,7 +33,7 @@ const RadioButtons = ({
   return (
     <>
       <fieldset
-        aria-labelledby={`${uuid}-legend`}
+        aria-labelledby={`button-rating-${title}`}
         className={styles.container}
         disabled={disabled}
         onChange={(e) => {
@@ -42,14 +42,14 @@ const RadioButtons = ({
         }}
       >
         {title && (
-          <legend id={`${uuid}-legend`}>
+          <legend id={`button-rating-${title}`}>
             <h2>{title}</h2>
           </legend>
         )}
         {options?.map((option, index) => (
           <label htmlFor={`${uuid}-${index}`} key={index}>
             <input
-              aria-labelledby={option}
+              aria-labelledby={`${option}-label`}
               className={styles.button}
               defaultChecked={index === selectedOption}
               id={`${uuid}-${index}`}
@@ -57,7 +57,9 @@ const RadioButtons = ({
               type="radio"
               value={index}
             />
-            <span className={styles.label}>{option}</span>
+            <span className={styles.label} id={`${option}-label`}>
+              {option}
+            </span>
           </label>
         ))}
       </fieldset>

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -33,7 +33,6 @@ const RadioButtons = ({
   return (
     <>
       <fieldset
-        aria-labelledby={`button-rating-${title}`}
         className={styles.container}
         disabled={disabled}
         onChange={(e) => {
@@ -42,7 +41,7 @@ const RadioButtons = ({
         }}
       >
         {title && (
-          <legend id={`button-rating-${title}`}>
+          <legend>
             <h2>{title}</h2>
           </legend>
         )}

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -41,7 +41,11 @@ const RadioButtons = ({
           updateSelectedOption(selectedValue)
         }}
       >
-        {title && <legend id={`${uuid}-legend`}>{title}</legend>}
+        {title && (
+          <legend id={`${uuid}-legend`}>
+            <h2>{title}</h2>
+          </legend>
+        )}
         {options?.map((option, index) => (
           <label htmlFor={title} key={index}>
             <input

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -49,7 +49,6 @@ const RadioButtons = ({
         {options?.map((option, index) => (
           <label htmlFor={title} key={index}>
             <input
-              aria-checked={index === selectedOption}
               aria-label={option}
               checked={index === selectedOption}
               className={styles.button}

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -37,15 +37,17 @@ const RadioButtons = ({
       <fieldset
         className={styles.container}
         disabled={disabled}
-        onChange={
-          (e) =>
-            updateSelectedOption(parseInt((e.target as HTMLInputElement).value))
-          // eslint-disable-next-line react/jsx-curly-newline
-        }
+        onChange={(e) => {
+          const selectedValue = parseInt((e.target as HTMLInputElement).value)
+          updateSelectedOption(selectedValue)
+        }}
       >
+        <legend>{title}</legend>
         {options?.map((option, index) => (
           <label key={index}>
             <input
+              aria-checked={index === selectedOption}
+              aria-label={option}
               className={styles.button}
               defaultChecked={index === selectedOption}
               id={`${index}`}

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/label-has-for */
 import React, { useEffect, useState } from 'react'
 import { v4 } from 'uuid'
 
@@ -33,8 +32,8 @@ const RadioButtons = ({
 
   return (
     <>
-      {title && <h3>{title}</h3>}
       <fieldset
+        aria-labelledby={`${uuid}-legend`}
         className={styles.container}
         disabled={disabled}
         onChange={(e) => {
@@ -42,17 +41,16 @@ const RadioButtons = ({
           updateSelectedOption(selectedValue)
         }}
       >
-        <legend>{title}</legend>
+        {title && <legend id={`${uuid}-legend`}>{title}</legend>}
         {options?.map((option, index) => (
-          <label key={index}>
+          <label htmlFor={`${uuid}-${index}`} key={index}>
             <input
               aria-checked={index === selectedOption}
               aria-label={option}
+              checked={index === selectedOption}
               className={styles.button}
-              defaultChecked={index === selectedOption}
-              id={`${index}`}
+              id={`${uuid}-${index}`}
               name={uuid}
-              tabIndex={0}
               type="radio"
               value={index}
             />

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -47,11 +47,11 @@ const RadioButtons = ({
           </legend>
         )}
         {options?.map((option, index) => (
-          <label htmlFor={title} key={index}>
+          <label htmlFor={`${uuid}-${index}`} key={index}>
             <input
-              aria-label={option}
-              checked={index === selectedOption}
+              aria-labelledby={option}
               className={styles.button}
+              defaultChecked={index === selectedOption}
               id={`${uuid}-${index}`}
               name={uuid}
               type="radio"

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -43,7 +43,7 @@ const RadioButtons = ({
       >
         {title && <legend id={`${uuid}-legend`}>{title}</legend>}
         {options?.map((option, index) => (
-          <label htmlFor={`${uuid}-${index}`} key={index}>
+          <label htmlFor={title} key={index}>
             <input
               aria-checked={index === selectedOption}
               aria-label={option}

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -52,7 +52,7 @@ const RadioButtons = ({
               defaultChecked={index === selectedOption}
               id={`${index}`}
               name={uuid}
-              tabIndex={index}
+              tabIndex={0}
               type="radio"
               value={index}
             />

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -39,9 +39,13 @@ const SatisfactionSlider = ({
 
   return (
     <>
-      <fieldset className={styles.wrapper} disabled={disabled}>
+      <fieldset
+        aria-labelledby={`satisfaction-slider-${title}`}
+        className={styles.wrapper}
+        disabled={disabled}
+      >
         {title && (
-          <legend id={`${title}-legend`}>
+          <legend id={`satisfaction-slider-${title}`}>
             <h2>{title}</h2>
           </legend>
         )}
@@ -49,9 +53,6 @@ const SatisfactionSlider = ({
         <input aria-hidden="true" name={title} type="hidden" value={number} />
         <input
           aria-label={title}
-          aria-valuemax={max}
-          aria-valuemin={min}
-          aria-valuenow={number}
           max={max}
           min={min}
           name={title}
@@ -60,7 +61,7 @@ const SatisfactionSlider = ({
           type="range"
           value={number}
         />
-        <output>{number}</output>
+        <output className={styles.output}>{number}</output>
       </fieldset>
     </>
   )

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -49,7 +49,14 @@ const SatisfactionSlider = ({
           value={scaledNumber}
         />
         <input
-          aria-label={title}
+          aria-label={
+            title +
+            ' with ' +
+            min +
+            ' being the worst rating and ' +
+            max +
+            ' being the best rating'
+          }
           aria-valuemax={max}
           aria-valuemin={min}
           aria-valuenow={scaledNumber}

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -66,7 +66,7 @@ const SatisfactionSlider = ({
           type="range"
           value={number}
         />
-        <output className={styles.invisiblea11ylabel}>{number}</output>
+        <output className={styles.invisibleA11yLabel}>{number}</output>
       </fieldset>
     </>
   )

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -47,7 +47,7 @@ const SatisfactionSlider = ({
             <h2>
               <span className={styles.invisibleA11yLabel}>
                 {t('Slider.valueDescription')}
-              </span>
+              </span>{' '}
               {title}
             </h2>
           </legend>

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -69,7 +69,6 @@ const SatisfactionSlider = ({
           type="range"
           value={number}
         />
-        <output className={styles.invisibleA11yLabel}>{number}</output>
       </fieldset>
     </>
   )

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -50,7 +50,12 @@ const SatisfactionSlider = ({
           </legend>
         )}
         <Smiley percentage={scaledNumber} />
-        <input aria-hidden="true" name={title} type="hidden" value={number} />
+        <input
+          aria-hidden="true"
+          name={title}
+          type="hidden"
+          value={scaledNumber}
+        />
         <input
           aria-label={title}
           max={max}
@@ -61,7 +66,7 @@ const SatisfactionSlider = ({
           type="range"
           value={number}
         />
-        <output className={styles.output}>{number}</output>
+        <output className={styles.invisiblea11ylabel}>{number}</output>
       </fieldset>
     </>
   )

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -42,12 +42,7 @@ const SatisfactionSlider = ({
       <fieldset className={styles.wrapper} disabled={disabled}>
         {title && <legend id={`${title}-legend`}>{title}</legend>}
         <Smiley percentage={scaledNumber} />
-        <input
-          aria-hidden="true"
-          name={title}
-          type="hidden"
-          value={scaledNumber}
-        />
+        <input aria-hidden="true" name={title} type="hidden" value={number} />
         <input
           aria-label={
             title +
@@ -59,7 +54,7 @@ const SatisfactionSlider = ({
           }
           aria-valuemax={max}
           aria-valuemin={min}
-          aria-valuenow={scaledNumber}
+          aria-valuenow={number}
           max={max}
           min={min}
           name={title}

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -51,11 +51,11 @@ const SatisfactionSlider = ({
         <input
           aria-label={
             title +
-            ' with ' +
+            ', ' +
             min +
-            ' being the worst rating and ' +
+            ' is the worst rating, ' +
             max +
-            ' being the best rating'
+            ' is the best rating'
           }
           aria-valuemax={max}
           aria-valuemin={min}

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
 
 import styles from '../styles/SatisfactionSlider.module.css'
@@ -23,6 +24,7 @@ const SatisfactionSlider = ({
   updateCallback
 }: SatisfactionSliderProps) => {
   const [number, updateNumber] = useState(initial || 0)
+  const t = useTranslations()
 
   useEffect(
     () => {
@@ -39,14 +41,15 @@ const SatisfactionSlider = ({
 
   return (
     <>
-      <fieldset
-        aria-labelledby={`satisfaction-slider-${title}`}
-        className={styles.wrapper}
-        disabled={disabled}
-      >
+      <fieldset className={styles.wrapper} disabled={disabled}>
         {title && (
-          <legend id={`satisfaction-slider-${title}`}>
-            <h2>{title}</h2>
+          <legend>
+            <h2>
+              <span className={styles.invisibleA11yLabel}>
+                {t('Slider.valueDescription')}
+              </span>
+              {title}
+            </h2>
           </legend>
         )}
         <Smiley percentage={scaledNumber} />

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -41,9 +41,19 @@ const SatisfactionSlider = ({
     <>
       {title && <h3>{title}</h3>}
       <fieldset className={styles.wrapper} disabled={disabled}>
+        <legend>{title}</legend>
         <Smiley percentage={scaledNumber} />
-        <input name={title} type="hidden" value={scaledNumber} />
         <input
+          aria-hidden="true"
+          name={title}
+          type="hidden"
+          value={scaledNumber}
+        />
+        <input
+          aria-label={title}
+          aria-valuemax={max}
+          aria-valuemin={min}
+          aria-valuenow={number}
           max={max}
           min={min}
           name={title}
@@ -52,6 +62,7 @@ const SatisfactionSlider = ({
           type="range"
           value={number}
         />
+        <output>{number}</output>
       </fieldset>
     </>
   )

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -39,9 +39,8 @@ const SatisfactionSlider = ({
 
   return (
     <>
-      {title && <h3>{title}</h3>}
       <fieldset className={styles.wrapper} disabled={disabled}>
-        <legend>{title}</legend>
+        {title && <legend id={`${title}-legend`}>{title}</legend>}
         <Smiley percentage={scaledNumber} />
         <input
           aria-hidden="true"
@@ -53,7 +52,7 @@ const SatisfactionSlider = ({
           aria-label={title}
           aria-valuemax={max}
           aria-valuemin={min}
-          aria-valuenow={number}
+          aria-valuenow={scaledNumber}
           max={max}
           min={min}
           name={title}

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -40,18 +40,15 @@ const SatisfactionSlider = ({
   return (
     <>
       <fieldset className={styles.wrapper} disabled={disabled}>
-        {title && <legend id={`${title}-legend`}>{title}</legend>}
+        {title && (
+          <legend id={`${title}-legend`}>
+            <h2>{title}</h2>
+          </legend>
+        )}
         <Smiley percentage={scaledNumber} />
         <input aria-hidden="true" name={title} type="hidden" value={number} />
         <input
-          aria-label={
-            title +
-            ', ' +
-            min +
-            ' is the worst rating, ' +
-            max +
-            ' is the best rating'
-          }
+          aria-label={title}
           aria-valuemax={max}
           aria-valuemin={min}
           aria-valuenow={number}

--- a/components/Smiley.tsx
+++ b/components/Smiley.tsx
@@ -1,8 +1,6 @@
 import styles from '../styles/SatisfactionSlider.module.css'
 
 type Props = {
-  max?: number
-  min?: number
   percentage: number
 }
 
@@ -20,7 +18,9 @@ const EMOJI_MAP: EmojiMap = {
   90: '😄'
 }
 
-const Smiley = ({ max = 10, min = 0, percentage }: Props) => {
+const Smiley = ({ percentage }: Props) => {
+  const emojiKeys = Object.keys(EMOJI_MAP).map(Number)
+  const [min, max] = [Math.min(...emojiKeys), Math.max(...emojiKeys)]
   const matchingEmoji = Object.keys(EMOJI_MAP).find(
     (key) => parseInt(key) >= percentage * 100
   )
@@ -28,8 +28,8 @@ const Smiley = ({ max = 10, min = 0, percentage }: Props) => {
 
   return (
     <span
-      aria-valuemax={max}
-      aria-valuemin={min}
+      aria-valuemax={max / 10}
+      aria-valuemin={min / 10}
       aria-valuenow={parseInt(matchingEmoji) / 10}
       className={styles.large}
       role="slider"

--- a/components/Smiley.tsx
+++ b/components/Smiley.tsx
@@ -24,7 +24,20 @@ const Smiley = ({ percentage }: Props) => {
   )
   if (!matchingEmoji) return null
 
-  return <span className={styles.large}>{EMOJI_MAP[matchingEmoji]}</span>
+  return (
+    <span
+      aria-label={`Satisfaction level: ${matchingEmoji}`}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={percentage * 100}
+      className={styles.large}
+      role="slider"
+      tabIndex={0}
+      title={`Satisfaction level: ${matchingEmoji}`}
+    >
+      {EMOJI_MAP[matchingEmoji]}
+    </span>
+  )
 }
 
 export default Smiley

--- a/components/Smiley.tsx
+++ b/components/Smiley.tsx
@@ -19,25 +19,12 @@ const EMOJI_MAP: EmojiMap = {
 }
 
 const Smiley = ({ percentage }: Props) => {
-  const emojiKeys = Object.keys(EMOJI_MAP).map(Number)
-  const [min, max] = [Math.min(...emojiKeys), Math.max(...emojiKeys)]
   const matchingEmoji = Object.keys(EMOJI_MAP).find(
     (key) => parseInt(key) >= percentage * 100
   )
   if (!matchingEmoji) return null
 
-  return (
-    <span
-      aria-valuemax={max / 10}
-      aria-valuemin={min / 10}
-      aria-valuenow={parseInt(matchingEmoji) / 10}
-      className={styles.large}
-      role="slider"
-      tabIndex={0}
-    >
-      {EMOJI_MAP[matchingEmoji]}
-    </span>
-  )
+  return <span className={styles.large}>{EMOJI_MAP[matchingEmoji]}</span>
 }
 
 export default Smiley

--- a/components/Smiley.tsx
+++ b/components/Smiley.tsx
@@ -1,6 +1,8 @@
 import styles from '../styles/SatisfactionSlider.module.css'
 
 type Props = {
+  max?: number
+  min?: number
   percentage: number
 }
 
@@ -18,9 +20,7 @@ const EMOJI_MAP: EmojiMap = {
   90: '😄'
 }
 
-const Smiley = ({ percentage }: Props) => {
-  const min = 0
-  const max = 10
+const Smiley = ({ max = 10, min = 0, percentage }: Props) => {
   const matchingEmoji = Object.keys(EMOJI_MAP).find(
     (key) => parseInt(key) >= percentage * 100
   )
@@ -28,18 +28,12 @@ const Smiley = ({ percentage }: Props) => {
 
   return (
     <span
-      aria-label={`Satisfaction rating: ${
-        parseInt(matchingEmoji) / 10
-      }, ${min} is the worst rating, ${max} is the best rating`}
       aria-valuemax={max}
       aria-valuemin={min}
       aria-valuenow={parseInt(matchingEmoji) / 10}
       className={styles.large}
       role="slider"
       tabIndex={0}
-      title={`Satisfaction rating: ${
-        parseInt(matchingEmoji) / 10
-      }, ${min} is the worst rating, ${max} is the best rating`}
     >
       {EMOJI_MAP[matchingEmoji]}
     </span>

--- a/components/Smiley.tsx
+++ b/components/Smiley.tsx
@@ -19,6 +19,8 @@ const EMOJI_MAP: EmojiMap = {
 }
 
 const Smiley = ({ percentage }: Props) => {
+  const min = 0
+  const max = 10
   const matchingEmoji = Object.keys(EMOJI_MAP).find(
     (key) => parseInt(key) >= percentage * 100
   )
@@ -26,14 +28,18 @@ const Smiley = ({ percentage }: Props) => {
 
   return (
     <span
-      aria-label={`Satisfaction level: ${matchingEmoji}`}
-      aria-valuemax={100}
-      aria-valuemin={0}
-      aria-valuenow={percentage * 100}
+      aria-label={`Satisfaction rating: ${
+        parseInt(matchingEmoji) / 10
+      }, ${min} is the worst rating, ${max} is the best rating`}
+      aria-valuemax={max}
+      aria-valuemin={min}
+      aria-valuenow={parseInt(matchingEmoji) / 10}
       className={styles.large}
       role="slider"
       tabIndex={0}
-      title={`Satisfaction level: ${matchingEmoji}`}
+      title={`Satisfaction rating: ${
+        parseInt(matchingEmoji) / 10
+      }, ${min} is the worst rating, ${max} is the best rating`}
     >
       {EMOJI_MAP[matchingEmoji]}
     </span>

--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -52,7 +52,11 @@ const Stars = ({
 
   return (
     <>
-      {title && <h3>{title}</h3>}
+      {title && (
+        <legend id={`rating-${title}`}>
+          <h2>{title}</h2>
+        </legend>
+      )}
       <fieldset
         className={styles.container}
         onChange={

--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -52,12 +52,8 @@ const Stars = ({
 
   return (
     <>
-      {title && (
-        <legend id={`rating-${title}`}>
-          <h2>{title}</h2>
-        </legend>
-      )}
       <fieldset
+        aria-labelledby={`star-rating-${title}`}
         className={styles.container}
         onChange={
           (e) =>
@@ -65,18 +61,23 @@ const Stars = ({
           // eslint-disable-next-line react/jsx-curly-newline
         }
       >
+        {title && (
+          <legend id={`star-rating-${title}`}>
+            <h2>{title}</h2>
+          </legend>
+        )}
         {Array(number)
           .fill(null)
           .map((_, index) => (
             <React.Fragment key={index}>
               <input
                 className={starStyles.hidden}
-                id={`rating-${index}`}
+                id={`star-rating-${index}`}
                 name="rating"
                 type="radio"
                 value={`${index}`}
               />
-              <label htmlFor={`rating-${index}`}>
+              <label htmlFor={`star-rating-${index}`}>
                 <span>
                   {selectedOption >= index ? <Star selected /> : <Star />}
                 </span>

--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -53,7 +53,6 @@ const Stars = ({
   return (
     <>
       <fieldset
-        aria-labelledby={`star-rating-${title}`}
         className={styles.container}
         onChange={
           (e) =>
@@ -62,7 +61,7 @@ const Stars = ({
         }
       >
         {title && (
-          <legend id={`star-rating-${title}`}>
+          <legend>
             <h2>{title}</h2>
           </legend>
         )}

--- a/components/TextResponse.tsx
+++ b/components/TextResponse.tsx
@@ -30,26 +30,28 @@ const TextResponse = ({
 
   return (
     <>
-      {title && (
-        <h2>
-          <label htmlFor={title}>{title}</label>
-        </h2>
-      )}
-      <textarea
-        className={`${styles.textbox} ${disabled ? 'disabled' : ''}`}
-        disabled={disabled}
-        id={title}
-        name={title}
-        onChange={(e) => updateUserText(e.target.value)}
-        placeholder={placeholder}
-        // Focus the textarea on render
-        ref={(textboxRef) => {
-          if (textboxRef) {
-            textboxRef.focus()
-          }
-        }}
-        value={userText}
-      />
+      <fieldset className={styles.container}>
+        {title && (
+          <legend>
+            <h2>{title}</h2>
+          </legend>
+        )}
+        <textarea
+          className={`${styles.textbox} ${disabled ? 'disabled' : ''}`}
+          disabled={disabled}
+          id={title}
+          name={title}
+          onChange={(e) => updateUserText(e.target.value)}
+          placeholder={placeholder}
+          // Focus the textarea on render
+          ref={(textboxRef) => {
+            if (textboxRef) {
+              textboxRef.focus()
+            }
+          }}
+          value={userText}
+        />
+      </fieldset>
     </>
   )
 }

--- a/components/TextResponse.tsx
+++ b/components/TextResponse.tsx
@@ -31,9 +31,9 @@ const TextResponse = ({
   return (
     <>
       {title && (
-        <h3>
+        <h2>
           <label htmlFor={title}>{title}</label>
-        </h3>
+        </h2>
       )}
       <textarea
         className={`${styles.textbox} ${disabled ? 'disabled' : ''}`}

--- a/config.yaml
+++ b/config.yaml
@@ -70,7 +70,7 @@ i18n:
     TextResponse:
       enterText: "Enter text..."
     Slider:
-      valueDescription: "The slider goes goes from a lower rating to a higher rating."
+      valueDescription: "The slider goes from a lower rating to a higher rating."
   fr-FR: 
     index: 
       next: "Suivant"

--- a/config.yaml
+++ b/config.yaml
@@ -69,6 +69,8 @@ i18n:
       noConnection: "Disconnected from the internet."
     TextResponse:
       enterText: "Enter text..."
+    Slider:
+      valueDescription: "The slider goes goes from a lower rating to a higher rating."
   fr-FR: 
     index: 
       next: "Suivant"

--- a/styles/SatisfactionSlider.module.css
+++ b/styles/SatisfactionSlider.module.css
@@ -10,3 +10,8 @@
   gap: 10px;
   justify-content: center;
 }
+
+.output {
+  display: none;
+  visibility: hidden;
+}

--- a/styles/SatisfactionSlider.module.css
+++ b/styles/SatisfactionSlider.module.css
@@ -11,12 +11,7 @@
   justify-content: center;
 }
 
-.output {
-  display: none;
-  visibility: hidden;
-}
-
-.invisiblea11ylabel {
+.invisibleA11yLabel {
   display: inline-block;
   height: 0;
   overflow: hidden;

--- a/styles/SatisfactionSlider.module.css
+++ b/styles/SatisfactionSlider.module.css
@@ -15,3 +15,10 @@
   display: none;
   visibility: hidden;
 }
+
+.invisiblea11ylabel {
+  display: inline-block;
+  height: 0;
+  overflow: hidden;
+  width: 0;
+}

--- a/styles/TextResponse.module.css
+++ b/styles/TextResponse.module.css
@@ -24,13 +24,7 @@
   outline: none;
 }
 .container {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  gap: 20px;
-  font-size: 20px;
   border: none;
-  overflow: scroll;
   -ms-overflow-style: none; /* Internet Explorer 10+ */
   scrollbar-width: none; /* Firefox */
 }

--- a/styles/TextResponse.module.css
+++ b/styles/TextResponse.module.css
@@ -23,3 +23,14 @@
   border: 3px solid #333;
   outline: none;
 }
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  gap: 20px;
+  font-size: 20px;
+  border: none;
+  overflow: scroll;
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: none; /* Firefox */
+}


### PR DESCRIPTION
Adds accessibility to survey component JSX. 

- `<h3>` --> `<h2>` because of a11y heading hierarchy rules
- Adding ARIA to make survey components more clear for AT users
- Adding a `<legend>` for each `<fieldset>` 