### PR TITLE
Heading and onSubmit a11y adjustments

### DIFF
--- a/components/NavButtons.tsx
+++ b/components/NavButtons.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { useTranslations } from 'next-intl'
+
+type Props = {
+  activeQuestion: number
+  connected: boolean
+  lastQuestion: boolean
+  nextQuestion: () => void
+  prevQuestion: () => void
+  surveyOver: boolean
+}
+
+const NavButtons = ({
+  activeQuestion,
+  connected,
+  lastQuestion,
+  nextQuestion,
+  prevQuestion,
+  surveyOver
+}: Props) => {
+  const t = useTranslations()
+  return (
+    <>
+      <button
+        disabled={activeQuestion === 0 || !connected}
+        onClick={prevQuestion}
+      >
+        {t('index.prev')}
+      </button>
+      <button
+        disabled={surveyOver || !connected}
+        onClick={nextQuestion}
+        type={lastQuestion ? 'submit' : 'button'}
+      >
+        {lastQuestion ? t('index.submitFeedback') : t('index.next')}
+      </button>
+    </>
+  )
+}
+
+export default NavButtons

--- a/components/NavButtons.tsx
+++ b/components/NavButtons.tsx
@@ -2,37 +2,32 @@ import React from 'react'
 import { useTranslations } from 'next-intl'
 
 type Props = {
-  activeQuestion: number
-  connected: boolean
-  lastQuestion: boolean
+  isLastQuestion: boolean
+  nextDisabled: boolean
   nextQuestion: () => void
+  prevDisabled: boolean
   prevQuestion: () => void
-  surveyOver: boolean
 }
 
 const NavButtons = ({
-  activeQuestion,
-  connected,
-  lastQuestion,
+  isLastQuestion,
+  nextDisabled,
   nextQuestion,
-  prevQuestion,
-  surveyOver
+  prevDisabled,
+  prevQuestion
 }: Props) => {
   const t = useTranslations()
   return (
     <>
-      <button
-        disabled={activeQuestion === 0 || !connected}
-        onClick={prevQuestion}
-      >
+      <button disabled={prevDisabled} onClick={prevQuestion}>
         {t('index.prev')}
       </button>
       <button
-        disabled={surveyOver || !connected}
+        disabled={nextDisabled}
         onClick={nextQuestion}
-        type={lastQuestion ? 'submit' : 'button'}
+        type={isLastQuestion ? 'submit' : 'button'}
       >
-        {lastQuestion ? t('index.submitFeedback') : t('index.next')}
+        {isLastQuestion ? t('index.submitFeedback') : t('index.next')}
       </button>
     </>
   )

--- a/components/QuestionRenderer.tsx
+++ b/components/QuestionRenderer.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable complexity */
 import { useTranslations } from 'next-intl'
+import { MutableRefObject } from 'react'
 
 import { RadioButtonProps, RadioButtons } from './RadioButtons'
 import {
@@ -23,10 +25,14 @@ export type Question = {
 // eslint-disable-next-line complexity
 const QuestionRenderer = ({
   disabled,
+  headingRefs,
+  index,
   question,
   updateCallback
 }: {
   disabled: boolean
+  headingRefs: MutableRefObject<HTMLHeadingElement[]>
+  index: number
   question: Question
   updateCallback?: (update: unknown) => void
 }) => {
@@ -41,78 +47,105 @@ const QuestionRenderer = ({
     </>
   )
 
-  // TODO: move title rendering to this component?
-  // Only if there is a way to make it stable across all components
+  // TODO: Reduce complexity
 
-  switch (type) {
-    case 'info':
-      return (
-        <>
-          <h1>{title}</h1>
-          <h2>{subtitle}</h2>
-        </>
-      )
-    case 'radio':
-      if (!('options' in question)) return failure
-      return (
-        <RadioButtons
-          defaultOptionIndex={question.defaultOptionIndex}
-          disabled={disabled}
-          options={question.options}
-          title={title}
-          updateCallback={updateCallback}
-        />
-      )
-    case 'stars':
-      return (
-        <Stars
-          defaultOptionIndex={
-            'defaultOptionIndex' in question
-              ? question.defaultOptionIndex
-              : undefined
-          }
-          number={'number' in question ? question.number : undefined}
-          title={title}
-          updateCallback={updateCallback}
-        />
-      )
-    case 'satisfaction':
-      return (
-        <SatisfactionSlider
-          disabled={disabled}
-          initial={'initial' in question ? question.initial : undefined}
-          max={'max' in question ? question.max : undefined}
-          min={'min' in question ? question.min : undefined}
-          step={'step' in question ? question.step : undefined}
-          title={title}
-          updateCallback={updateCallback}
-        />
-      )
-    case 'textarea':
-      return (
-        <TextResponse
-          disabled={disabled}
-          placeholder={
-            'placeholder' in question
-              ? question.placeholder
-              : t('TextResponse.enterText')
-          }
-          title={title}
-          updateCallback={updateCallback}
-        />
-      )
-    default:
-      console.warn(`Invalid question type ${type}`)
-      return (
-        <>
-          <h1>Error</h1>
-          <p>
-            The configuration contains an invalid question type{' '}
-            <code>{type || 'undefined'}</code>. See console for details.
-          </p>
-        </>
-      )
+  const renderQuestion = (type: string) => {
+    switch (type) {
+      case 'radio':
+        if (!('options' in question)) return failure
+        return (
+          <RadioButtons
+            defaultOptionIndex={question.defaultOptionIndex}
+            disabled={disabled}
+            options={question.options}
+            updateCallback={updateCallback}
+          />
+        )
+      case 'stars':
+        return (
+          <Stars
+            defaultOptionIndex={
+              'defaultOptionIndex' in question
+                ? question.defaultOptionIndex
+                : undefined
+            }
+            number={'number' in question ? question.number : undefined}
+            updateCallback={updateCallback}
+          />
+        )
+      case 'satisfaction':
+        return (
+          <SatisfactionSlider
+            disabled={disabled}
+            initial={'initial' in question ? question.initial : undefined}
+            max={'max' in question ? question.max : undefined}
+            min={'min' in question ? question.min : undefined}
+            step={'step' in question ? question.step : undefined}
+            title={title}
+            updateCallback={updateCallback}
+          />
+        )
+      case 'textarea':
+        return (
+          <TextResponse
+            disabled={disabled}
+            placeholder={
+              'placeholder' in question
+                ? question.placeholder
+                : t('TextResponse.enterText')
+            }
+            title={title}
+            updateCallback={updateCallback}
+          />
+        )
+      default:
+        console.warn(`Invalid question type ${type}`)
+        return (
+          <>
+            <h1>Error</h1>
+            <p>
+              The configuration contains an invalid question type{' '}
+              <code>{type || 'undefined'}</code>. See console for details.
+            </p>
+          </>
+        )
+    }
   }
+  if (type === 'info') {
+    return (
+      <>
+        {title && (
+          <h1 aria-live="assertive" id={`heading-${index}`} tabIndex={-1}>
+            {title}
+          </h1>
+        )}
+        {subtitle && <h2>{subtitle}</h2>}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <fieldset className="container">
+        {title && (
+          <legend>
+            <h1
+              aria-live="assertive"
+              className={type === 'textarea' ? 'alignLeft' : ''}
+              id={`heading-${index}`}
+              ref={(el: HTMLHeadingElement) =>
+                (headingRefs.current[index] = el)}
+              tabIndex={-1}
+            >
+              {title}
+            </h1>
+          </legend>
+        )}
+        {subtitle && <h2>{subtitle}</h2>}
+        {renderQuestion(type)}
+      </fieldset>
+    </>
+  )
 }
 
 export default QuestionRenderer

--- a/components/QuestionRenderer.tsx
+++ b/components/QuestionRenderer.tsx
@@ -124,7 +124,7 @@ const QuestionRenderer = ({
   return (
     <fieldset className="container">
       {title && (
-        <legend>
+        <>
           <h1
             aria-live="assertive"
             className={type === 'textarea' ? 'alignLeft' : ''}
@@ -133,7 +133,8 @@ const QuestionRenderer = ({
           >
             {title}
           </h1>
-        </legend>
+          <legend className="invisibleA11yLabel">{title}</legend>
+        </>
       )}
       {subtitle && <h2>{subtitle}</h2>}
       {renderQuestion(type)}

--- a/components/QuestionRenderer.tsx
+++ b/components/QuestionRenderer.tsx
@@ -133,8 +133,10 @@ const QuestionRenderer = ({
               aria-live="assertive"
               className={type === 'textarea' ? 'alignLeft' : ''}
               id={`heading-${index}`}
-              ref={(el: HTMLHeadingElement) =>
-                (headingRefs.current[index] = el)}
+              ref={
+                (el: HTMLHeadingElement) => (headingRefs.current[index] = el)
+                // eslint-disable-next-line react/jsx-curly-newline
+              }
               tabIndex={-1}
             >
               {title}

--- a/components/QuestionRenderer.tsx
+++ b/components/QuestionRenderer.tsx
@@ -112,7 +112,12 @@ const QuestionRenderer = ({
     return (
       <>
         {title && (
-          <h1 aria-live="assertive" id={`heading-${index}`} tabIndex={-1}>
+          <h1
+            aria-live="assertive"
+            className="info"
+            id={`heading-${index}`}
+            tabIndex={-1}
+          >
             {title}
           </h1>
         )}
@@ -122,23 +127,23 @@ const QuestionRenderer = ({
   }
 
   return (
-    <fieldset className="container">
+    <>
       {title && (
-        <>
-          <h1
-            aria-live="assertive"
-            className={type === 'textarea' ? 'alignLeft' : ''}
-            id={`heading-${index}`}
-            tabIndex={-1}
-          >
-            {title}
-          </h1>
-          <legend className="invisibleA11yLabel">{title}</legend>
-        </>
+        <h1
+          aria-live="assertive"
+          className={type === 'textarea' ? 'alignLeft' : ''}
+          id={`heading-${index}`}
+          tabIndex={-1}
+        >
+          {title}
+        </h1>
       )}
-      {subtitle && <h2>{subtitle}</h2>}
-      {renderQuestion(type)}
-    </fieldset>
+      <fieldset className="container">
+        {title && <legend className="invisibleA11yLabel">{title}</legend>}
+        {subtitle && <h2>{subtitle}</h2>}
+        {renderQuestion(type)}
+      </fieldset>
+    </>
   )
 }
 

--- a/components/QuestionRenderer.tsx
+++ b/components/QuestionRenderer.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable complexity */
 import { useTranslations } from 'next-intl'
-import { MutableRefObject } from 'react'
 
 import { RadioButtonProps, RadioButtons } from './RadioButtons'
 import {
@@ -25,13 +24,11 @@ export type Question = {
 // eslint-disable-next-line complexity
 const QuestionRenderer = ({
   disabled,
-  headingRefs,
   index,
   question,
   updateCallback
 }: {
   disabled: boolean
-  headingRefs: MutableRefObject<HTMLHeadingElement[]>
   index: number
   question: Question
   updateCallback?: (update: unknown) => void
@@ -125,28 +122,22 @@ const QuestionRenderer = ({
   }
 
   return (
-    <>
-      <fieldset className="container">
-        {title && (
-          <legend>
-            <h1
-              aria-live="assertive"
-              className={type === 'textarea' ? 'alignLeft' : ''}
-              id={`heading-${index}`}
-              ref={
-                (el: HTMLHeadingElement) => (headingRefs.current[index] = el)
-                // eslint-disable-next-line react/jsx-curly-newline
-              }
-              tabIndex={-1}
-            >
-              {title}
-            </h1>
-          </legend>
-        )}
-        {subtitle && <h2>{subtitle}</h2>}
-        {renderQuestion(type)}
-      </fieldset>
-    </>
+    <fieldset className="container">
+      {title && (
+        <legend>
+          <h1
+            aria-live="assertive"
+            className={type === 'textarea' ? 'alignLeft' : ''}
+            id={`heading-${index}`}
+            tabIndex={-1}
+          >
+            {title}
+          </h1>
+        </legend>
+      )}
+      {subtitle && <h2>{subtitle}</h2>}
+      {renderQuestion(type)}
+    </fieldset>
   )
 }
 

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { v4 } from 'uuid'
 
 import styles from '../styles/RadioButtons.module.css'
@@ -28,6 +28,11 @@ const RadioButtons = ({
 
   const uuid = v4()
 
+  const onSelectionChange = useCallback((e) => {
+    const selectedValue = parseInt((e.target as HTMLInputElement).value)
+    updateSelectedOption(selectedValue)
+  }, [])
+
   return (
     <div className={styles.container}>
       {options?.map((option, index) => (
@@ -39,11 +44,19 @@ const RadioButtons = ({
             disabled={disabled}
             id={`${uuid}-${index}`}
             name={uuid}
-            onChange={(e) => {
-              const selectedValue = parseInt(
-                (e.target as HTMLInputElement).value
-              )
-              updateSelectedOption(selectedValue)
+            onChange={onSelectionChange}
+            ref={(radioRef) => {
+              // If there is no default selected option, set focus to first radio button
+              if (radioRef && index === 0 && selectedOption < 0) {
+                radioRef.focus()
+                // If there is a default selected option, set focus to that option
+              } else if (
+                radioRef &&
+                selectedOption === defaultOptionIndex &&
+                index === selectedOption
+              ) {
+                radioRef.focus()
+              }
             }}
             type="radio"
             value={index}

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -7,14 +7,12 @@ export type RadioButtonProps = {
   defaultOptionIndex?: number
   disabled?: boolean
   options: string[]
-  title?: string
   updateCallback?: (update: number) => void
 }
 const RadioButtons = ({
   defaultOptionIndex = -1,
   disabled = false,
   options,
-  title,
   updateCallback
 }: RadioButtonProps) => {
   const [selectedOption, updateSelectedOption] = useState(defaultOptionIndex)
@@ -31,40 +29,31 @@ const RadioButtons = ({
   const uuid = v4()
 
   return (
-    <>
-      <fieldset
-        className={styles.container}
-        disabled={disabled}
-        onChange={(e) => {
-          const selectedValue = parseInt((e.target as HTMLInputElement).value)
-          updateSelectedOption(selectedValue)
-        }}
-      >
-        {title && (
-          <legend>
-            <h1 aria-live="assertive" tabIndex={-1}>
-              {title}
-            </h1>
-          </legend>
-        )}
-        {options?.map((option, index) => (
-          <label htmlFor={`${uuid}-${index}`} key={index}>
-            <input
-              aria-labelledby={`${option}-label`}
-              className={styles.button}
-              defaultChecked={index === selectedOption}
-              id={`${uuid}-${index}`}
-              name={uuid}
-              type="radio"
-              value={index}
-            />
-            <span className={styles.label} id={`${option}-label`}>
-              {option}
-            </span>
-          </label>
-        ))}
-      </fieldset>
-    </>
+    <div className={styles.container}>
+      {options?.map((option, index) => (
+        <label htmlFor={`${uuid}-${index}`} key={index}>
+          <input
+            aria-labelledby={`${option}-label`}
+            className={styles.button}
+            defaultChecked={index === selectedOption}
+            disabled={disabled}
+            id={`${uuid}-${index}`}
+            name={uuid}
+            onChange={(e) => {
+              const selectedValue = parseInt(
+                (e.target as HTMLInputElement).value
+              )
+              updateSelectedOption(selectedValue)
+            }}
+            type="radio"
+            value={index}
+          />
+          <span className={styles.label} id={`${option}-label`}>
+            {option}
+          </span>
+        </label>
+      ))}
+    </div>
   )
 }
 export { RadioButtons }

--- a/components/RadioButtons.tsx
+++ b/components/RadioButtons.tsx
@@ -42,7 +42,9 @@ const RadioButtons = ({
       >
         {title && (
           <legend>
-            <h2 className={styles.title}>{title}</h2>
+            <h1 aria-live="assertive" tabIndex={-1}>
+              {title}
+            </h1>
           </legend>
         )}
         {options?.map((option, index) => (

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -41,35 +41,27 @@ const SatisfactionSlider = ({
 
   return (
     <>
-      <fieldset className={styles.wrapper} disabled={disabled}>
-        {title && (
-          <legend>
-            <h1 aria-live="assertive" tabIndex={-1}>
-              <span className={styles.invisibleA11yLabel}>
-                {t('Slider.valueDescription')}
-              </span>{' '}
-              {title}
-            </h1>
-          </legend>
-        )}
-        <Smiley percentage={scaledNumber} />
-        <input
-          aria-hidden="true"
-          name={title}
-          type="hidden"
-          value={scaledNumber}
-        />
-        <input
-          aria-label={title}
-          max={max}
-          min={min}
-          name={title}
-          onChange={(e) => updateNumber(parseInt(e.target.value))}
-          step={step}
-          type="range"
-          value={number}
-        />
-      </fieldset>
+      <span className={styles.invisibleA11yLabel}>
+        {t('Slider.valueDescription')}
+      </span>{' '}
+      <Smiley percentage={scaledNumber} />
+      <input
+        aria-hidden="true"
+        disabled={disabled}
+        name={title}
+        type="hidden"
+        value={scaledNumber}
+      />
+      <input
+        aria-label={title}
+        max={max}
+        min={min}
+        name={title}
+        onChange={(e) => updateNumber(parseInt(e.target.value))}
+        step={step}
+        type="range"
+        value={number}
+      />
     </>
   )
 }

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -43,17 +43,17 @@ const SatisfactionSlider = ({
     <>
       <span className={styles.invisibleA11yLabel}>
         {t('Slider.valueDescription')}
-      </span>{' '}
+      </span>
       <Smiley percentage={scaledNumber} />
       <input
         aria-hidden="true"
-        disabled={disabled}
         name={title}
         type="hidden"
         value={scaledNumber}
       />
       <input
         aria-label={title}
+        disabled={disabled}
         max={max}
         min={min}
         name={title}

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -44,12 +44,12 @@ const SatisfactionSlider = ({
       <fieldset className={styles.wrapper} disabled={disabled}>
         {title && (
           <legend>
-            <h2>
+            <h1 aria-live="assertive" tabIndex={-1}>
               <span className={styles.invisibleA11yLabel}>
                 {t('Slider.valueDescription')}
               </span>{' '}
               {title}
-            </h2>
+            </h1>
           </legend>
         )}
         <Smiley percentage={scaledNumber} />

--- a/components/SatisfactionSlider.tsx
+++ b/components/SatisfactionSlider.tsx
@@ -1,7 +1,5 @@
 import { useTranslations } from 'next-intl'
-import { useEffect, useState } from 'react'
-
-import styles from '../styles/SatisfactionSlider.module.css'
+import { useCallback, useEffect, useState } from 'react'
 
 import Smiley from './Smiley'
 
@@ -39,25 +37,29 @@ const SatisfactionSlider = ({
 
   const scaledNumber = (number - min) / (max - min)
 
+  const onSliderChange = useCallback(
+    (e) => updateNumber(parseInt(e.target.value)),
+    []
+  )
+
   return (
     <>
-      <span className={styles.invisibleA11yLabel}>
-        {t('Slider.valueDescription')}
-      </span>
+      <span className="invisibleA11yLabel">{t('Slider.valueDescription')}</span>
       <Smiley percentage={scaledNumber} />
-      <input
-        aria-hidden="true"
-        name={title}
-        type="hidden"
-        value={scaledNumber}
-      />
+      <input name={title} type="hidden" value={scaledNumber} />
       <input
         aria-label={title}
         disabled={disabled}
         max={max}
         min={min}
         name={title}
-        onChange={(e) => updateNumber(parseInt(e.target.value))}
+        onChange={onSliderChange}
+        // Set focus to input on render
+        ref={(sliderRef) => {
+          if (sliderRef) {
+            sliderRef.focus()
+          }
+        }}
         step={step}
         type="range"
         value={number}

--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -61,7 +61,9 @@ const Stars = ({
       >
         {title && (
           <legend>
-            <h2>{title}</h2>
+            <h1 aria-live="assertive" tabIndex={-1}>
+              {title}
+            </h1>
           </legend>
         )}
         {Array(number)

--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import starStyles from '../styles/Stars.module.css'
 
@@ -48,6 +48,9 @@ const Stars = ({
     [selectedOption]
   )
 
+  const onStarChange = useCallback((e) => {
+    return updateSelectedOption(parseInt((e.target as HTMLInputElement).value))
+  }, [])
   return (
     <div className={starStyles.container}>
       {Array(number)
@@ -55,17 +58,23 @@ const Stars = ({
         .map((_, index) => (
           <React.Fragment key={index}>
             <input
-              className={starStyles.hidden}
+              className={` ${starStyles.input} invisibleA11yLabel`}
               id={`star-rating-${index}`}
               name="rating"
-              onChange={
-                (e) => {
-                  return updateSelectedOption(
-                    parseInt((e.target as HTMLInputElement).value)
-                  )
+              onChange={onStarChange}
+              ref={(starRef) => {
+                // If there is no default selected option, set focus to first radio button
+                if (starRef && index === 0 && selectedOption < 0) {
+                  starRef.focus()
+                  // If there is a default selected option, set focus to that option
+                } else if (
+                  starRef &&
+                  selectedOption === defaultOptionIndex &&
+                  index === selectedOption
+                ) {
+                  starRef.focus()
                 }
-                // eslint-disable-next-line react/jsx-curly-newline
-              }
+              }}
               type="radio"
               value={`${index}`}
             />

--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -5,11 +5,10 @@ import starStyles from '../styles/Stars.module.css'
 export type StarsProps = {
   defaultOptionIndex?: number
   number?: number
-  title?: string
   updateCallback?: (update: number) => void
 }
 
-const Star = ({ selected }: { selected?: boolean }) => {
+const Star = ({ index, selected }: { index?: string; selected?: boolean }) => {
   let fill = 'rgba(30, 30, 30, 0.3)'
   if (selected) {
     fill = 'rgba(255, 214, 0, 0.8)'
@@ -17,6 +16,7 @@ const Star = ({ selected }: { selected?: boolean }) => {
 
   return (
     <svg
+      aria-label={index ? `${index + 1} stars` : ''}
       className={starStyles.star}
       height="55"
       width="54"
@@ -35,7 +35,6 @@ const Star = ({ selected }: { selected?: boolean }) => {
 const Stars = ({
   defaultOptionIndex = -1,
   number = 5,
-  title,
   updateCallback
 }: StarsProps) => {
   const [selectedOption, updateSelectedOption] = useState(defaultOptionIndex)
@@ -50,42 +49,38 @@ const Stars = ({
   )
 
   return (
-    <>
-      <fieldset
-        className={starStyles.container}
-        onChange={
-          (e) =>
-            updateSelectedOption(parseInt((e.target as HTMLInputElement).value))
-          // eslint-disable-next-line react/jsx-curly-newline
-        }
-      >
-        {title && (
-          <legend>
-            <h1 aria-live="assertive" tabIndex={-1}>
-              {title}
-            </h1>
-          </legend>
-        )}
-        {Array(number)
-          .fill(null)
-          .map((_, index) => (
-            <React.Fragment key={index}>
-              <input
-                className={starStyles.hidden}
-                id={`star-rating-${index}`}
-                name="rating"
-                type="radio"
-                value={`${index}`}
-              />
-              <label htmlFor={`star-rating-${index}`}>
-                <span>
-                  {selectedOption >= index ? <Star selected /> : <Star />}
-                </span>
-              </label>
-            </React.Fragment>
-          ))}
-      </fieldset>
-    </>
+    <div className={starStyles.container}>
+      {Array(number)
+        .fill(null)
+        .map((_, index) => (
+          <React.Fragment key={index}>
+            <input
+              className={starStyles.hidden}
+              id={`star-rating-${index}`}
+              name="rating"
+              onChange={
+                (e) => {
+                  return updateSelectedOption(
+                    parseInt((e.target as HTMLInputElement).value)
+                  )
+                }
+                // eslint-disable-next-line react/jsx-curly-newline
+              }
+              type="radio"
+              value={`${index}`}
+            />
+            <label htmlFor={`star-rating-${index}`}>
+              <span>
+                {selectedOption >= index ? (
+                  <Star index={`${index}`} selected />
+                ) : (
+                  <Star />
+                )}
+              </span>
+            </label>
+          </React.Fragment>
+        ))}
+    </div>
   )
 }
 export { Stars }

--- a/components/TextResponse.tsx
+++ b/components/TextResponse.tsx
@@ -33,7 +33,13 @@ const TextResponse = ({
       <fieldset className={styles.container}>
         {title && (
           <legend>
-            <h2 className={styles.alignLeft}>{title}</h2>
+            <h1
+              aria-live="assertive"
+              className={styles.alignLeft}
+              tabIndex={-1}
+            >
+              {title}
+            </h1>
           </legend>
         )}
         <textarea

--- a/components/TextResponse.tsx
+++ b/components/TextResponse.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 // @ts-expect-error This package is typescripted, but not uploaded to npm correctly
 import { useDebounce } from 'use-lodash-debounce'
 
@@ -28,6 +28,8 @@ const TextResponse = ({
     [debouncedUserText]
   )
 
+  const onTextChange = useCallback((e) => updateUserText(e.target.value), [])
+
   return (
     <>
       <textarea
@@ -35,7 +37,7 @@ const TextResponse = ({
         disabled={disabled}
         id={title}
         name={title}
-        onChange={(e) => updateUserText(e.target.value)}
+        onChange={onTextChange}
         placeholder={placeholder}
         // Focus the textarea on render
         ref={(textboxRef) => {

--- a/components/TextResponse.tsx
+++ b/components/TextResponse.tsx
@@ -30,34 +30,21 @@ const TextResponse = ({
 
   return (
     <>
-      <fieldset className={styles.container}>
-        {title && (
-          <legend>
-            <h1
-              aria-live="assertive"
-              className={styles.alignLeft}
-              tabIndex={-1}
-            >
-              {title}
-            </h1>
-          </legend>
-        )}
-        <textarea
-          className={`${styles.textbox} ${disabled ? 'disabled' : ''}`}
-          disabled={disabled}
-          id={title}
-          name={title}
-          onChange={(e) => updateUserText(e.target.value)}
-          placeholder={placeholder}
-          // Focus the textarea on render
-          ref={(textboxRef) => {
-            if (textboxRef) {
-              textboxRef.focus()
-            }
-          }}
-          value={userText}
-        />
-      </fieldset>
+      <textarea
+        className={`${styles.textbox} ${disabled ? 'disabled' : ''}`}
+        disabled={disabled}
+        id={title}
+        name={title}
+        onChange={(e) => updateUserText(e.target.value)}
+        placeholder={placeholder}
+        // Focus the textarea on render
+        ref={(textboxRef) => {
+          if (textboxRef) {
+            textboxRef.focus()
+          }
+        }}
+        value={userText}
+      />
     </>
   )
 }

--- a/components/stories/RadioButtons.story.tsx
+++ b/components/stories/RadioButtons.story.tsx
@@ -17,10 +17,12 @@ export const Default = () => (
 )
 
 export const WithTitle = () => (
-  <RadioButtons
-    defaultOptionIndex={2}
-    options={['one', 'two', 'three', 'four', 'five']}
-    title="Pick a number"
-    updateCallback={action('Option is selected')}
-  />
+  <>
+    <h1>How many stars are there in the sky?</h1>
+    <RadioButtons
+      defaultOptionIndex={2}
+      options={['one', 'two', 'three', 'four', 'five']}
+      updateCallback={action('Option is selected')}
+    />
+  </>
 )

--- a/components/stories/SatisfactionSlider.story.tsx
+++ b/components/stories/SatisfactionSlider.story.tsx
@@ -28,13 +28,16 @@ export const Default = () => (
 )
 
 export const WithTitleAndCustomScale = () => (
-  <Wrapper>
-    <SatisfactionSlider
-      initial={7}
-      max={15}
-      min={-5}
-      title="How much do you like the bus?"
-      updateCallback={action('Slider is updated')}
-    />
-  </Wrapper>
+  <>
+    <h1>How much do you like the bus?</h1>
+    <Wrapper>
+      <SatisfactionSlider
+        initial={7}
+        max={15}
+        min={-5}
+        title="How much do you like the bus?"
+        updateCallback={action('Slider is updated')}
+      />
+    </Wrapper>
+  </>
 )

--- a/components/stories/Stars.story.tsx
+++ b/components/stories/Stars.story.tsx
@@ -14,9 +14,8 @@ export const Default = () => (
 )
 
 export const WithTitle = () => (
-  <Stars
-    number={50}
-    title="How many stars are there in the sky?"
-    updateCallback={action('Option is selected')}
-  />
+  <>
+    <h1>How many stars are there in the sky?</h1>
+    <Stars number={50} updateCallback={action('Option is selected')} />
+  </>
 )

--- a/components/stories/TextResponse.story.tsx
+++ b/components/stories/TextResponse.story.tsx
@@ -32,11 +32,14 @@ export const Default = () => (
 
 export const WithTitle = () => (
   <Wrapper>
-    <TextResponse
-      placeholder="Pizza is delicious"
-      title="Describe your favorite food here"
-      updateCallback={action('Text is updated')}
-    />
+    <>
+      <h1>How much do you like the bus?</h1>
+      <TextResponse
+        placeholder="Pizza is delicious"
+        title="Describe your favorite food here"
+        updateCallback={action('Text is updated')}
+      />
+    </>
   </Wrapper>
 )
 

--- a/config.yaml
+++ b/config.yaml
@@ -69,6 +69,7 @@ i18n:
     index: 
       next: "Next 〉"
       prev: "〈 Previous"
+      submitFeedback: "Submit"
       completion: "Thanks!"
       completionSubtitle: "Your response has been submitted."
     alert:

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import type { GetStaticProps, NextPage } from 'next'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { v4 } from 'uuid'
 import { useTranslations } from 'next-intl'
 import { useSocket, useSocketEvent } from 'socket.io-react-hook'
@@ -25,7 +25,7 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
       'SOCKET_SERVER_URL env variable not set. There is nowhere to send survey results!'
     )
   }
-
+  const headingRefs = useRef<Array<HTMLHeadingElement>>([])
   const [activeQuestion, setActiveQuestion] = useState(0)
   const t = useTranslations()
 
@@ -49,6 +49,11 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
     })
   }
 
+  // On each question render, set focus to h1 for AT
+  useEffect(() => {
+    headingRefs.current[activeQuestion]?.focus()
+  }, [activeQuestion])
+
   if (!questions || questions.length === 0) {
     return <div>No questions defined</div>
   }
@@ -56,7 +61,6 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
   const isLastQuestion = activeQuestion === questions.length - 1
   const surveyOver = activeQuestion >= questions.length
 
-  // TODO: add a wrapper here to blur focus when changing questions
   const prevQuestion = () => setActiveQuestion(activeQuestion - 1)
   const nextQuestion = () => setActiveQuestion(activeQuestion + 1)
 
@@ -87,6 +91,8 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
           >
             <QuestionRenderer
               disabled={!connected}
+              headingRefs={headingRefs}
+              index={index}
               question={question}
               updateCallback={(update: unknown) => {
                 return activeQuestion === index

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import type { GetStaticProps, NextPage } from 'next'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { v4 } from 'uuid'
 import { useTranslations } from 'next-intl'
 import { useSocket, useSocketEvent } from 'socket.io-react-hook'
@@ -25,7 +25,6 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
       'SOCKET_SERVER_URL env variable not set. There is nowhere to send survey results!'
     )
   }
-  const headingRefs = useRef<Array<HTMLHeadingElement>>([])
   const [activeQuestion, setActiveQuestion] = useState(0)
   const t = useTranslations()
 
@@ -48,11 +47,6 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
       value: update
     })
   }
-
-  // On each question render, set focus to h1 for AT
-  useEffect(() => {
-    headingRefs.current[activeQuestion]?.focus()
-  }, [activeQuestion])
 
   if (!questions || questions.length === 0) {
     return <div>No questions defined</div>
@@ -91,7 +85,6 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
           >
             <QuestionRenderer
               disabled={!connected}
-              headingRefs={headingRefs}
               index={index}
               question={question}
               updateCallback={(update: unknown) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -53,12 +53,15 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
     return <div>No questions defined</div>
   }
 
-  const lastQuestion = activeQuestion === questions.length - 1
+  const isLastQuestion = activeQuestion === questions.length - 1
   const surveyOver = activeQuestion >= questions.length
 
   // TODO: add a wrapper here to blur focus when changing questions
   const prevQuestion = () => setActiveQuestion(activeQuestion - 1)
   const nextQuestion = () => setActiveQuestion(activeQuestion + 1)
+
+  const prevDisabled = activeQuestion === 0 || !connected
+  const nextDisabled = surveyOver || !connected
 
   return (
     <main
@@ -109,12 +112,11 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
       )}
       <section className={styles.buttons}>
         <NavButtons
-          activeQuestion={activeQuestion}
-          connected={connected}
-          lastQuestion={lastQuestion}
+          isLastQuestion={isLastQuestion}
+          nextDisabled={nextDisabled}
           nextQuestion={nextQuestion}
+          prevDisabled={prevDisabled}
           prevQuestion={prevQuestion}
-          surveyOver={surveyOver}
         />
       </section>
     </main>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -101,7 +101,7 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
 
       {surveyOver && (
         <div className={styles.question}>
-          <h1 aria-live="assertive" tabIndex={-1}>
+          <h1 aria-live="assertive" className="info" tabIndex={-1}>
             {t('index.completion')}
           </h1>
           {t('index.completionSubtitle') !== 'index.completionSubtitle' && (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import QuestionRenderer, { Question } from '../components/QuestionRenderer'
 import styles from '../styles/base.module.css'
 import config from '../config.yaml'
 import { Alert } from '../components/Alert'
+import NavButtons from '../components/NavButtons'
 
 const sessionUuid = v4()
 
@@ -52,6 +53,7 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
     return <div>No questions defined</div>
   }
 
+  const lastQuestion = activeQuestion === questions.length - 1
   const surveyOver = activeQuestion >= questions.length
 
   // TODO: add a wrapper here to blur focus when changing questions
@@ -97,23 +99,23 @@ const Home: NextPage = ({ questions, socketServerUrl }: Props) => {
 
       {surveyOver && (
         <div className={styles.question}>
-          <h1>{t('index.completion')}</h1>
+          <h1 aria-live="assertive" tabIndex={-1}>
+            {t('index.completion')}
+          </h1>
           {t('index.completionSubtitle') !== 'index.completionSubtitle' && (
             <h2>{t('index.completionSubtitle')}</h2>
           )}
         </div>
       )}
-
       <section className={styles.buttons}>
-        <button
-          disabled={activeQuestion === 0 || !connected}
-          onClick={prevQuestion}
-        >
-          {t('index.prev')}
-        </button>
-        <button disabled={surveyOver || !connected} onClick={nextQuestion}>
-          {t('index.next')}
-        </button>
+        <NavButtons
+          activeQuestion={activeQuestion}
+          connected={connected}
+          lastQuestion={lastQuestion}
+          nextQuestion={nextQuestion}
+          prevQuestion={prevQuestion}
+          surveyOver={surveyOver}
+        />
       </section>
     </main>
   )

--- a/styles/RadioButtons.module.css
+++ b/styles/RadioButtons.module.css
@@ -1,17 +1,9 @@
 .container {
-  align-items: center;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 0 20px;
   font-size: 20px;
-  border: none;
-  overflow: scroll;
-  -ms-overflow-style: none; /* Internet Explorer 10+ */
-  scrollbar-width: none; /* Firefox */
   width: 100%;
-}
-.container::-webkit-scrollbar {
-  display: none; /* Safari and Chrome */
 }
 
 .button,

--- a/styles/SatisfactionSlider.module.css
+++ b/styles/SatisfactionSlider.module.css
@@ -2,15 +2,6 @@
   font-size: 128px;
 }
 
-.wrapper {
-  align-items: center;
-  border: none;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  justify-content: center;
-}
-
 .invisibleA11yLabel {
   display: inline-block;
   height: 0;

--- a/styles/SatisfactionSlider.module.css
+++ b/styles/SatisfactionSlider.module.css
@@ -1,10 +1,3 @@
 .large {
   font-size: 128px;
 }
-
-.invisibleA11yLabel {
-  display: inline-block;
-  height: 0;
-  overflow: hidden;
-  width: 0;
-}

--- a/styles/Stars.module.css
+++ b/styles/Stars.module.css
@@ -6,14 +6,18 @@
   height: 45px;
   width: 45px;
   overflow: unset;
+  margin-right: 15px;
 }
 .star:hover {
   opacity: 0.5;
 }
 
+.input:focus + label path {
+  outline: 1px solid blue;
+}
+
 .container {
   margin-top: 1.25em;
-  gap: 20px;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;

--- a/styles/Stars.module.css
+++ b/styles/Stars.module.css
@@ -12,8 +12,6 @@
 }
 
 .container {
-  border: none;
-  justify-content: center;
   margin-top: 1.25em;
   gap: 20px;
   display: flex;

--- a/styles/TextResponse.module.css
+++ b/styles/TextResponse.module.css
@@ -24,7 +24,7 @@
   outline: none;
 }
 
-h2.alignLeft {
+h1.alignLeft {
   width: 100%;
   text-align: left;
   /* Padding keeps header in line with input text */

--- a/styles/TextResponse.module.css
+++ b/styles/TextResponse.module.css
@@ -23,16 +23,3 @@
   border: 3px solid #333;
   outline: none;
 }
-
-h1.alignLeft {
-  width: 100%;
-  text-align: left;
-  /* Padding keeps header in line with input text */
-  padding-left: 1rem;
-}
-
-.container {
-  border: none;
-  -ms-overflow-style: none; /* Internet Explorer 10+ */
-  scrollbar-width: none; /* Firefox */
-}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,11 +32,16 @@ h3 {
   text-align: center;
 }
 
-fieldset h1,
+h1,
 h2 {
   font-size: 1.5em;
   font-weight: 400;
   margin-bottom: 0.5em;
+}
+
+h1.info {
+  font-size: 2em;
+  font-weight: 700;
 }
 
 h1.alignLeft {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -46,6 +46,13 @@ h1.alignLeft {
   width: 100%;
 }
 
+.invisibleA11yLabel {
+  display: inline-block;
+  height: 0;
+  overflow: hidden;
+  width: 0;
+}
+
 .container {
   align-items: center;
   border: none;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,8 +30,9 @@ h1, h2, h3 {
   text-align: center;
 }
 
-h2 {
+fieldset h1, h2 {
   font-size: 1.5em;
   font-weight: 400;
+  margin-bottom: .5em;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -26,13 +26,38 @@ h1 {
   margin: 0;
 }
 
-h1, h2, h3 {
+h1,
+h2,
+h3 {
   text-align: center;
 }
 
-fieldset h1, h2 {
+fieldset h1,
+h2 {
   font-size: 1.5em;
   font-weight: 400;
-  margin-bottom: .5em;
+  margin-bottom: 0.5em;
 }
 
+h1.alignLeft {
+  /* Padding keeps header in line with input text */
+  padding-left: 1rem;
+  text-align: left;
+  width: 100%;
+}
+
+.container {
+  align-items: center;
+  border: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  justify-content: center;
+  overflow: scroll;
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: none; /* Firefox */
+}
+
+.container::-webkit-scrollbar {
+  display: none; /* Safari and Chrome */
+}


### PR DESCRIPTION
- Adds `tabIndex` and `aria-assertive` to headings to ensure they are announced to users relying on AT.
- Changes question titles to `h1` elements
- "Next" button changes to "Submit" and has `type="submit"` on survey last question.
- Navigation buttons moved into separate component to limit `index.tsx` complexity.
- `h1` elements moved out of question components
- Focus set on `h1` when question is changed