### PR TITLE
Correctly specify node 18 version

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install npm packages using cache
         uses: bahmutov/npm-install@v1
       - name: Lint code

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
 /** @type {import('next').NextConfig} */
 const fs = require('fs')
+const { Readable } = require('stream')
+const { finished } = require('stream/promises')
 
 const withYaml = require('next-plugin-yaml')
 
@@ -20,7 +22,7 @@ module.exports = async () => {
     )
     const downloadedConfig = await fetch(CONFIG_YML_URL)
     const fileStream = fs.createWriteStream('./config.yaml')
-    await downloadedConfig.body.pipe(fileStream)
+    await finished(Readable.fromWeb(downloadedConfig.body).pipe(fileStream))
     console.log(`Downloaded config.yaml`)
   }
   return withYaml(nextConfig)

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "survey",
   "version": "0.1.0",
-  "engines": {
-    "node": "<18"
-  },
+  "engines": { "node": "18.x" },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Zeit requires node 18 (the version of node this project uses) to be specified in a specific way. This PR does this.