### PR TITLE
Fix survey container height

### DIFF
--- a/styles/base.module.css
+++ b/styles/base.module.css
@@ -1,9 +1,11 @@
 .wrapper {
+  bottom: 0;
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: 90vh 10vh;
-  height: 100vh;
-  width: 100vw;
+  grid-template-rows: 90% 10%;
+  position: fixed;
+  top: 0;
+  width: 100%;
 }
 
 .question {


### PR DESCRIPTION
Viewport units are terrible units to use, especially when dealing with mobile devices.
This PR fixes that, so that the Previous/Next buttons are initially visible on mobile devices. Previously, users had to scroll to access these buttons.