### PR TITLE
Improve star highlighting behavior

### DIFF
--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -8,39 +8,18 @@ export type StarsProps = {
   updateCallback?: (update: number) => void
 }
 
-const Star = ({
-  hovered,
-  index,
-  onStarHover,
-  onStarLeave,
-  selected
-}: {
-  hovered?: boolean
-  index?: string
-  onStarHover: () => void
-  onStarLeave: () => void
-  selected?: boolean
-}) => {
-  // Fill with yellow if the star is selected or hovered, otherwise fill is gray
-  const fill =
-    selected || hovered ? 'rgba(255, 214, 0, 0.8)' : 'rgba(30, 30, 30, 0.3'
+const Star = ({ index, selected }: { index?: string; selected?: boolean }) => {
+  const fill = selected ? 'rgba(255, 214, 0, 0.8)' : 'rgba(30, 30, 30, 0.3)'
 
   return (
     <svg
       aria-label={index ? `${Number(index) + 1} stars` : ''}
       className={starStyles.star}
       height="55"
-      onMouseEnter={onStarHover}
-      onMouseLeave={onStarLeave}
       width="54"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path
-        d="M27,2.5 43,52.5 1,21.5H53.5L11,52.5"
-        style={{
-          fill
-        }}
-      />
+      <path d="M27,2.5 43,52.5 1,21.5H53.5L11,52.5" fill={fill} />
     </svg>
   )
 }
@@ -51,7 +30,6 @@ const Stars = ({
   updateCallback
 }: StarsProps) => {
   const [selectedOption, updateSelectedOption] = useState(defaultOptionIndex)
-  const [hoveredStar, setHoveredStar] = useState<number | null>(null)
 
   useEffect(
     () => {
@@ -65,14 +43,6 @@ const Stars = ({
   const onStarChange = useCallback((e) => {
     return updateSelectedOption(parseInt((e.target as HTMLInputElement).value))
   }, [])
-
-  const handleStarHover = (index: number) => {
-    setHoveredStar(index)
-  }
-
-  const handleStarLeave = () => {
-    setHoveredStar(null)
-  }
 
   return (
     <div className={starStyles.container}>
@@ -103,13 +73,7 @@ const Stars = ({
             />
             <label htmlFor={`star-rating-${index}`}>
               <span>
-                <Star
-                  hovered={hoveredStar !== null && index <= hoveredStar}
-                  index={`${index}`}
-                  onStarHover={() => handleStarHover(index)}
-                  onStarLeave={handleStarLeave}
-                  selected={selectedOption >= index}
-                />
+                <Star index={`${index}`} selected={selectedOption >= index} />
               </span>
             </label>
           </React.Fragment>

--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -9,17 +9,15 @@ export type StarsProps = {
 }
 
 const Star = ({ index, selected }: { index?: string; selected?: boolean }) => {
-  const fill = selected ? 'rgba(255, 214, 0, 0.8)' : 'rgba(30, 30, 30, 0.3)'
-
   return (
     <svg
       aria-label={index ? `${Number(index) + 1} stars` : ''}
-      className={starStyles.star}
+      className={`${starStyles.star} ${selected ? starStyles.selected : ''}`}
       height="55"
       width="54"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path d="M27,2.5 43,52.5 1,21.5H53.5L11,52.5" fill={fill} />
+      <path d="M27,2.5 43,52.5 1,21.5H53.5L11,52.5" fill="currentColor" />
     </svg>
   )
 }

--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -8,17 +8,30 @@ export type StarsProps = {
   updateCallback?: (update: number) => void
 }
 
-const Star = ({ index, selected }: { index?: string; selected?: boolean }) => {
-  let fill = 'rgba(30, 30, 30, 0.3)'
-  if (selected) {
-    fill = 'rgba(255, 214, 0, 0.8)'
-  }
+const Star = ({
+  hovered,
+  index,
+  onStarHover,
+  onStarLeave,
+  selected
+}: {
+  hovered?: boolean
+  index?: string
+  onStarHover: () => void
+  onStarLeave: () => void
+  selected?: boolean
+}) => {
+  // Fill with yellow if the star is selected or hovered, otherwise fill is gray
+  const fill =
+    selected || hovered ? 'rgba(255, 214, 0, 0.8)' : 'rgba(30, 30, 30, 0.3'
 
   return (
     <svg
       aria-label={index ? `${Number(index) + 1} stars` : ''}
       className={starStyles.star}
       height="55"
+      onMouseEnter={onStarHover}
+      onMouseLeave={onStarLeave}
       width="54"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -38,6 +51,7 @@ const Stars = ({
   updateCallback
 }: StarsProps) => {
   const [selectedOption, updateSelectedOption] = useState(defaultOptionIndex)
+  const [hoveredStar, setHoveredStar] = useState<number | null>(null)
 
   useEffect(
     () => {
@@ -51,6 +65,15 @@ const Stars = ({
   const onStarChange = useCallback((e) => {
     return updateSelectedOption(parseInt((e.target as HTMLInputElement).value))
   }, [])
+
+  const handleStarHover = (index: number) => {
+    setHoveredStar(index)
+  }
+
+  const handleStarLeave = () => {
+    setHoveredStar(null)
+  }
+
   return (
     <div className={starStyles.container}>
       {Array(number)
@@ -80,11 +103,13 @@ const Stars = ({
             />
             <label htmlFor={`star-rating-${index}`}>
               <span>
-                {selectedOption >= index ? (
-                  <Star index={`${index}`} selected />
-                ) : (
-                  <Star />
-                )}
+                <Star
+                  hovered={hoveredStar !== null && index <= hoveredStar}
+                  index={`${index}`}
+                  onStarHover={() => handleStarHover(index)}
+                  onStarLeave={handleStarLeave}
+                  selected={selectedOption >= index}
+                />
               </span>
             </label>
           </React.Fragment>

--- a/styles/Stars.module.css
+++ b/styles/Stars.module.css
@@ -8,8 +8,10 @@
   overflow: unset;
   margin-right: 15px;
 }
-.star:hover {
+.star:hover path {
   cursor: pointer;
+  fill: #ffd600;
+  opacity: 0.8;
 }
 
 .input:focus + label path {

--- a/styles/Stars.module.css
+++ b/styles/Stars.module.css
@@ -8,7 +8,7 @@
   overflow: unset;
   margin-right: 15px;
   color: #8C8C8C;
-  transition: color 0.15s ease-in-out;
+  transition: color 0.1s ease-in-out;
 }
 .star:hover {
   cursor: pointer;

--- a/styles/Stars.module.css
+++ b/styles/Stars.module.css
@@ -7,11 +7,15 @@
   width: 45px;
   overflow: unset;
   margin-right: 15px;
+  color: gray;
 }
-.star:hover path {
+.star:hover {
   cursor: pointer;
-  fill: #ffd600;
-  opacity: 0.8;
+  color: #a98d00;
+}
+
+.selected {
+  color: #ddb802;
 }
 
 .input:focus + label path {

--- a/styles/Stars.module.css
+++ b/styles/Stars.module.css
@@ -11,11 +11,14 @@
 }
 .star:hover {
   cursor: pointer;
-  color: #a98d00;
+  filter: brightness(1.5);
 }
 
 .selected {
   color: #ddb802;
+}
+.selected:hover {
+  filter: brightness(0.7);
 }
 
 .input:focus + label path {

--- a/styles/Stars.module.css
+++ b/styles/Stars.module.css
@@ -9,7 +9,7 @@
   margin-right: 15px;
 }
 .star:hover {
-  opacity: 0.5;
+  cursor: pointer;
 }
 
 .input:focus + label path {

--- a/styles/Stars.module.css
+++ b/styles/Stars.module.css
@@ -7,18 +7,19 @@
   width: 45px;
   overflow: unset;
   margin-right: 15px;
-  color: gray;
+  color: #8C8C8C;
+  transition: color 0.15s ease-in-out;
 }
 .star:hover {
   cursor: pointer;
-  filter: brightness(1.5);
+  color: #666666
 }
 
 .selected {
-  color: #ddb802;
+  color: #ffda1f;
 }
 .selected:hover {
-  filter: brightness(0.7);
+  color: #ffb300;
 }
 
 .input:focus + label path {


### PR DESCRIPTION
Previously, hovered stars were a lighter yellow. This could be misinterpreted as a half-star. So, I am making the highlight on hover a darker yellow
Inspired by [this tutorial's hovering behaviour](https://www.w3.org/WAI/tutorials/forms/custom-controls/#a-star-rating).

